### PR TITLE
align items start to prevent image from stretching

### DIFF
--- a/src/components/Person/Person.scss
+++ b/src/components/Person/Person.scss
@@ -2,6 +2,7 @@
   display: grid;
   grid-template-columns: 75px 1fr;
   gap: $space-default;
+  align-items: start;
 
   text-align: left;
   line-height: 1.4;


### PR DESCRIPTION
Fix for stretched image
<img width="433" alt="Screenshot 2022-03-14 at 16 13 07" src="https://user-images.githubusercontent.com/7050932/158202303-1f7e6980-3863-4b28-bb25-29da0615be25.png">
