### PR TITLE
Feat/29-blog-quote-component

### DIFF
--- a/src/components/PageSections/PageSections.vue
+++ b/src/components/PageSections/PageSections.vue
@@ -15,17 +15,19 @@
   import MultiTextSection from '@/components/PageSections/MultiTextSection/MultiTextSection'
   import NewsletterSection from '@/components/PageSections/NewsletterSection/NewsletterSection'
   import PeopleSection from '@/components/PageSections/PeopleSection/PeopleSection'
+  import QuoteSection from '@/components/PageSections/QuoteSection/QuoteSection'
   import TabsSection from '@/components/PageSections/TabsSection/TabsSection'
   import TextSection from '@/components/PageSections/TextSection/TextSection'
   import TimelineSection from '@/components/PageSections/TimelineSection/TimelineSection'
 
   const componentsByType = {
+    blog_quote: QuoteSection,
+    blog_text_section: TextSection,
     logo_section: LogoSection,
     multi_text_section: MultiTextSection,
     newsletter_section: NewsletterSection,
     people_section: PeopleSection,
     tabs_section: TabsSection,
-    blog_text_section: TextSection,
     timeline_section: TimelineSection,
   }
   const supportedTypes = Object.keys(componentsByType)

--- a/src/components/PageSections/QuoteSection/QuoteSection.fragment.graphql
+++ b/src/components/PageSections/QuoteSection/QuoteSection.fragment.graphql
@@ -1,0 +1,12 @@
+#import '../../Person/Person.fragment.graphql'
+
+fragment quoteSectionFragment on BlogQuoteRecord {
+  id
+  _modelApiKey
+  person {
+    ...personFragment
+  }
+  text {
+    value
+  }
+}

--- a/src/components/PageSections/QuoteSection/QuoteSection.scss
+++ b/src/components/PageSections/QuoteSection/QuoteSection.scss
@@ -1,0 +1,47 @@
+$quote-size: 32px;
+
+.quote-section {
+  display: block;
+}
+
+.quote-section .h3 {
+  font-weight: normal;
+}
+
+.quote-section__quote {
+  quotes: '\201c' '\201d';
+  position: relative;
+  margin: $space-large 0;
+  font-size: 1.2rem;
+  line-height: 1.6;
+
+  @media screen and (min-width: $breakpoint-medium) {
+    font-size: 1.5rem;
+  }
+}
+
+.quote-section__quote::before,
+.quote-section__quote::after {
+  position: absolute;
+  width: $quote-size;
+  height: $quote-size;
+  font-size: 4rem;
+  line-height: 1;
+}
+
+.quote-section__quote::before {
+  content: open-quote;
+  top: -$quote-size;
+  left: 0;
+}
+
+.quote-section__quote::after {
+  content: close-quote;
+  right: 0;
+  bottom: -$quote-size;
+}
+
+.quote-section__quotee {
+  padding-top: 5px;
+  text-align: right;
+}

--- a/src/components/PageSections/QuoteSection/QuoteSection.vue
+++ b/src/components/PageSections/QuoteSection/QuoteSection.vue
@@ -1,0 +1,35 @@
+<template>
+  <section :id="id" class="layout-section layout-section--padded layout-section--lined quote-section">
+    <figure class="layout-container">
+      <blockquote class="quote-section__quote">
+        <StructuredText
+          :text="text"
+        />
+      </blockquote>
+      <figcaption class="layout-container quote-section__quotee p small">
+        {{ person.name }}, {{ person.organisation }}
+      </figcaption>
+    </figure>
+  </section>
+</template>
+
+<script>
+  export default {
+    props: {
+      id: {
+        type: String,
+        required: true,
+      },
+      person: {
+        type: Object,
+        required: true,
+      },
+      text: {
+        type: Object,
+        required: true,
+      },
+    },
+  }
+</script>
+
+<style src="./QuoteSection.scss" lang="scss"></style>


### PR DESCRIPTION
This pull request includes the new QuoteSection. Since it depends on work done in #82 , you can't see anything yet using the preview link. When #82 is merged we can add the this component to the query in `blog/_slug.query.graphql` and `articles/_slug.query.graphql`.

Here's a screenshot of what it looks like:

<img width="1401" alt="Schermafbeelding 2022-03-16 om 14 09 12" src="https://user-images.githubusercontent.com/12752012/158598029-6d875949-657d-40df-9d7d-96e2ec4ef90d.png">
