### PR TITLE
Feat/GWW-72 convert large values to small value

### DIFF
--- a/src/assets/theme/chart-theme.json
+++ b/src/assets/theme/chart-theme.json
@@ -28,7 +28,7 @@
             "width": 2
         },
         "symbolSize": "5",
-        "symbol": "rect",
+        "symbol": "emptyCircle",
         "smooth": false
     },
     "radar": {
@@ -376,7 +376,6 @@
         ]
     },
     "dataZoom": {
-        "handleSize": "undefined%",
         "textStyle": {}
     },
     "markPoint": {

--- a/src/repo/reservoirRepo.js
+++ b/src/repo/reservoirRepo.js
@@ -6,9 +6,12 @@ const formatTimeSeries = (timeSeries) => {
     .map(capitalize)
     .join(' ')
 
-  const valueUnit = timeSeries[0]?.unit
+  // TODO: make sure this km2 comes from the backend again as an unit
+  // const valueUnit = timeSeries[0]?.unit
+  const valueUnit = 'km2'
 
-  const data = timeSeries.map(({ t, value }) => {
+  const data = timeSeries.map(({ t, value: valueInM2 }) => {
+    const value = (valueInM2 / 1000).toFixed(2)
     return [t, value]
   })
 

--- a/src/repo/reservoirRepo.js
+++ b/src/repo/reservoirRepo.js
@@ -11,7 +11,7 @@ const formatTimeSeries = (timeSeries) => {
   const valueUnit = 'km2'
 
   const data = timeSeries.map(({ t, value: valueInM2 }) => {
-    const value = (valueInM2 / 1000).toFixed(2)
+    const value = (valueInM2 / 1000000).toFixed(2)
     return [t, value]
   })
 


### PR DESCRIPTION
**Ticket:** ([GWW-72](https://issuetracker.deltares.nl/browse/GWW-72))
This pull request fixes that the values are very large, with a unit of m2. The actual value is also very (probably unnecessarily) precise, with 10 decimals. 

**Main feature**
- convert m2 to km2 and reduce to 2 decimals in the end.
- change chart styling based on feedback from earlier on: rounded symbols and drag handles on dataZoom

**Screenshot**
![image](https://user-images.githubusercontent.com/5878256/195594023-eaaf3c5c-5117-43c1-a714-dd18add50ab1.png)

**Deploy preview**
https://deploy-preview-164--global-water-watch-website.netlify.app/reservoir/92091
