### PR TITLE
Feat/GWW 85 navigate between reservoirs

### DIFF
--- a/src/components/DetailMap/DetailMap.vue
+++ b/src/components/DetailMap/DetailMap.vue
@@ -16,14 +16,9 @@
 
 <script>
   import { bbox, featureCollection } from '@turf/turf'
+  import { MAP_CENTER, MAP_ZOOM, MAPBOX_STYLE_DARK } from '@/lib/constants'
 
   let map
-
-  const MAP_ZOOM = 3
-  const WORLD_CENTER_LONGITUDE = 78.836854
-  const WORLD_CENTER_LATITUDE = 22.662175
-  const MAP_CENTER = [WORLD_CENTER_LONGITUDE, WORLD_CENTER_LATITUDE]
-  const MAPBOX_STYLE = 'mapbox://styles/mapbox/dark-v9'
 
   export default {
     props: {
@@ -43,7 +38,7 @@
           token: this.$config.mapBoxToken,
           center: MAP_CENTER,
           zoom: MAP_ZOOM,
-          style: MAPBOX_STYLE,
+          style: MAPBOX_STYLE_DARK,
         },
       }
     },
@@ -110,8 +105,8 @@
             source: reservoirName,
             layout: {},
             paint: {
-              'fill-color': '#8fdfef',
-              'fill-opacity': 0.2,
+              'fill-color': '#0AB6FF',
+              'fill-opacity': 0.7,
             },
           })
           map.addLayer({
@@ -120,7 +115,7 @@
             source: reservoirName,
             layout: {},
             paint: {
-              'line-color': '#8fdfef',
+              'line-color': '#0AB6FF',
               'line-width': 1,
             },
           })
@@ -129,11 +124,67 @@
           const boundingBox = bbox(allFeatures)
           map.fitBounds(boundingBox, { padding: 40 })
         })
+
+        map.addSource('reservoirsv10', {
+          type: 'vector',
+          url: 'mapbox://global-water-watch.reservoirs-v10',
+          promoteId: 'fid',
+        })
+
+        map.addLayer({
+          id: 'reservoirsv10-fill',
+          type: 'fill',
+          source: 'reservoirsv10',
+          'source-layer': 'reservoirsv10',
+          layout: {},
+          paint: {
+            'fill-color': '#8fdfef',
+            'fill-opacity': 0.4,
+          },
+        })
+
+        map.addLayer({
+          id: 'reservoirsv10-line',
+          type: 'line',
+          source: 'reservoirsv10',
+          'source-layer': 'reservoirsv10',
+          layout: {},
+          paint: {
+            'line-color': '#8fdfef',
+            'line-width': 0.8,
+          },
+        })
+
+        map.on('click', 'reservoirsv10-fill', (evt) => {
+          this.onReservoirClick(evt)
+        })
+
+        map.on('click', 'reservoirsv10-line', (evt) => {
+          this.onReservoirClick(evt)
+        })
+
+        if (this.reservoirs.length === 1) {
+          map.setFilter('reservoirsv10-fill', ['!=', 'fid', this.reservoirs[0]?.id])
+          map.setFilter('reservoirsv10-line', ['!=', 'fid', this.reservoirs[0]?.id])
+        } else {
+          map.setFilter('reservoirsv10-fill', ['in', 'fid', ''])
+          map.setFilter('reservoirsv10-line', ['in', 'fid', ''])
+        }
       },
 
       onMapCreated (map) {
         map.removeControl(map._logoControl)
         map.addControl(map._logoControl, 'top-right')
+      },
+
+      onReservoirClick (evt) {
+        const reservoir = evt.features?.[0]
+        if (!reservoir) {
+          return
+        }
+        const { fid } = reservoir.properties
+
+        this.$router.push({ path: `/reservoir/${fid}` })
       },
     },
   }

--- a/src/components/MapLayerReservoirs/MapLayerReservoirs.js
+++ b/src/components/MapLayerReservoirs/MapLayerReservoirs.js
@@ -1,3 +1,5 @@
+import { MAP_CENTER, MAP_ZOOM } from '@/lib/constants'
+
 export default {
   name: 'v-mapbox-reservoirs-layer',
 
@@ -11,6 +13,11 @@ export default {
       default: () => ({}),
     },
   },
+
+  data: () => ({
+    zoom: MAP_ZOOM || 0,
+    center: MAP_CENTER || [0, 0],
+  }),
 
   computed: {
     renderLayers () {
@@ -29,9 +36,36 @@ export default {
   methods: {
     deferredMountedTo () {
       if (!this.isInitialized) {
+        this.initialize()
         this.addLayer()
         this.isInitialized = true
       }
+    },
+
+    initialize () {
+      const map = this.getMap()
+      map.on('zoomend', this.onZoomEnd)
+      map.on('moveend', this.onMoveEnd)
+
+      this.onZoomEnd({ target: map })
+      this.onMoveEnd({ target: map })
+    },
+
+    onZoomEnd ({ target: map }) {
+      this.setMapCoordinates(map)
+    },
+
+    onMoveEnd ({ target: map }) {
+      this.setMapCoordinates(map)
+    },
+
+    setMapCoordinates (map) {
+      // get zoom and center of the current map when zooming ended
+      this.zoom = Math.round(map.getZoom())
+      this.center = map.getCenter().toArray()
+
+      // set the current zoom and center to the store
+      this.$store.commit('ui/SET_MAP_COORDINATES', { zoom: this.zoom, center: this.center })
     },
 
     addLayer () {

--- a/src/components/MapLayerReservoirs/MapLayerReservoirs.js
+++ b/src/components/MapLayerReservoirs/MapLayerReservoirs.js
@@ -61,7 +61,7 @@ export default {
 
     setMapCoordinates (map) {
       // get zoom and center of the current map when zooming ended
-      this.zoom = Math.round(map.getZoom())
+      this.zoom = map.getZoom()
       this.center = map.getCenter().toArray()
 
       // set the current zoom and center to the store

--- a/src/components/MapboxMap/MapboxMap.vue
+++ b/src/components/MapboxMap/MapboxMap.vue
@@ -30,11 +30,7 @@
 </template>
 
 <script>
-  const MAP_ZOOM = 3
-  const WORLD_CENTER_LONGITUDE = 18.4
-  const WORLD_CENTER_LATITUDE = 23
-  const MAP_CENTER = [WORLD_CENTER_LONGITUDE, WORLD_CENTER_LATITUDE]
-  const MAPBOX_STYLE = 'mapbox://styles/mapbox/light-v9'
+  import { MAP_ZOOM, MAP_CENTER, MAPBOX_STYLE } from '@/lib/constants'
 
   export default {
     data () {
@@ -52,6 +48,9 @@
       showExperimentalFeatures () {
         return this.$store.getters['ui/showExperimentalFeatures']
       },
+      mapCoordinates () {
+        return this.$store.getters['ui/mapCoordinates']
+      },
       reservoirLayers () {
         return this.$store.getters['reservoir-layers/layers']
       },
@@ -64,6 +63,12 @@
       onMapCreated (map) {
         map.removeControl(map._logoControl)
         map.addControl(map._logoControl, 'top-right')
+
+        this.mapConfig = {
+          ...this.mapConfig,
+          zoom: this.mapCoordinates.zoom,
+          center: this.mapCoordinates.center,
+        }
       },
 
       onMapLoaded () {

--- a/src/components/MapboxMap/MapboxMap.vue
+++ b/src/components/MapboxMap/MapboxMap.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-  import { MAP_ZOOM, MAP_CENTER, MAPBOX_STYLE } from '@/lib/constants'
+  import { MAP_ZOOM, MAP_CENTER, MAPBOX_STYLE_LIGHT } from '@/lib/constants'
 
   export default {
     data () {
@@ -39,7 +39,7 @@
           token: this.$config.mapBoxToken,
           center: MAP_CENTER,
           zoom: MAP_ZOOM,
-          style: this.$config.mapBoxStyle || MAPBOX_STYLE,
+          style: this.$config.mapBoxStyle || MAPBOX_STYLE_LIGHT,
         },
       }
     },

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -3,4 +3,5 @@ export const MAP_ZOOM = 3
 export const WORLD_CENTER_LONGITUDE = 18.4
 export const WORLD_CENTER_LATITUDE = 23
 export const MAP_CENTER = [WORLD_CENTER_LONGITUDE, WORLD_CENTER_LATITUDE]
-export const MAPBOX_STYLE = 'mapbox://styles/mapbox/light-v9'
+export const MAPBOX_STYLE_LIGHT = 'mapbox://styles/mapbox/light-v9'
+export const MAPBOX_STYLE_DARK = 'mapbox://styles/mapbox/dark-v9'

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,1 +1,6 @@
 export const LAYER_FADE_DURATION_MS = 1000
+export const MAP_ZOOM = 3
+export const WORLD_CENTER_LONGITUDE = 18.4
+export const WORLD_CENTER_LATITUDE = 23
+export const MAP_CENTER = [WORLD_CENTER_LONGITUDE, WORLD_CENTER_LATITUDE]
+export const MAPBOX_STYLE = 'mapbox://styles/mapbox/light-v9'

--- a/src/store/ui.js
+++ b/src/store/ui.js
@@ -1,13 +1,20 @@
+import { MAP_CENTER, MAP_ZOOM } from '@/lib/constants'
+
 export const state = () => ({
   mapReady: false,
   activeLayerName: 'Reservoirs',
   showExperimentalFeatures: process.env.IS_DEV,
+  mapCoordinates: {
+    zoom: MAP_ZOOM,
+    center: MAP_CENTER,
+  },
 })
 
 export const getters = {
   mapReady: state => state.mapReady,
   activeLayerName: state => state.activeLayerName,
   showExperimentalFeatures: state => state.showExperimentalFeatures,
+  mapCoordinates: state => state.mapCoordinates,
 }
 
 export const mutations = {
@@ -19,5 +26,8 @@ export const mutations = {
   },
   SET_SHOW_EXPERIMENTAL_FEATURES (state, payload) {
     state.showExperimentalFeatures = payload
+  },
+  SET_MAP_COORDINATES (state, payload) {
+    state.mapCoordinates = payload
   },
 }


### PR DESCRIPTION
Navigating between reservoirs ([GWW-82](https://issuetracker.deltares.nl/browse/GWW-85))

**Main features**
- refactor constants to the shared constants file
- add other reservoirs on reservoir page and highlight the selected one
- filter selected reservoir out of the main reservoirs layer
- make the map details reservoirs clickable so you don't need to leave the reservoir detail page to select one reservoir on the map.
- keep the map position on scroll and moveEnd in the store
- rerender saved map position on main map route if available

**Deploy preview**
https://deploy-preview-165--global-water-watch-website.netlify.app/