### PR TITLE
Feat/GWW-86 Redirect old urls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,18 +33,24 @@
 # Redirect aliases to primary domain
 [[redirects]]
   from = "https://globalwater.watch/*"
-  to = "https://www.globalwaterwatch.io/:splat"
+  to = "https://www.globalwaterwatch.earth/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://www.globalwater.watch/*"
-  to = "https://www.globalwaterwatch.io/:splat"
+  to = "https://www.globalwaterwatch.earth/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://global-water-watch-website.netlify.app/*"
-  to = "https://www.globalwaterwatch.io/:splat"
+  to = "https://www.globalwaterwatch.earth/:splat"
   status = 301
   force = true
+
+[[redirects]]
+from = "https://www.globalwaterwatch.io/*"
+to = "https://www.globalwaterwatch.earth/:splat"
+status = 301
+force = true


### PR DESCRIPTION
**Ticket:** [(GWW-86)](https://issuetracker.deltares.nl/browse/GWW-86)
Redirect .io url's to .earth (remove .watch). Till we have the .watch domain I decided to stil redirect it to .earth

**Main feature**
- feat: change redirect netlify.toml from .io to .earth