### PR TITLE
Fix/GWW-91 user drawn polygon

### DIFF
--- a/src/components/MapLayersPanel/MapLayersPanel.vue
+++ b/src/components/MapLayersPanel/MapLayersPanel.vue
@@ -14,6 +14,7 @@
     </v-radio-group>
 
     <v-btn
+      v-if="showExperimentalFeatures"
       small
       :disabled="!mapReady || isDrawing"
       @click="onDrawButtonClick"

--- a/src/store/ui.js
+++ b/src/store/ui.js
@@ -3,7 +3,7 @@ import { MAP_CENTER, MAP_ZOOM } from '@/lib/constants'
 export const state = () => ({
   mapReady: false,
   activeLayerName: 'Reservoirs',
-  showExperimentalFeatures: process.env.IS_DEV,
+  showExperimentalFeatures: true,
   mapCoordinates: {
     zoom: MAP_ZOOM,
     center: MAP_CENTER,


### PR DESCRIPTION
Ticket: [GWW-91](https://issuetracker.deltares.nl/browse/GWW-91) && [GWW-94](https://issuetracker.deltares.nl/browse/GWW-94)(no changes needed, it works as soon as the button is clickable)

Changes
- fix: Only show "Draw custom geometry" button if showExperimentalFeatures. To avoid having the button there when clicking it has no effect.
- fix: Enable showExperimentalFeatures. Drawing a custom polygon was the only experimental feature.