### PR TITLE
fix: Rename ProjectShare to PageShare

### DIFF
--- a/src/components/PageShare/PageShare.scss
+++ b/src/components/PageShare/PageShare.scss
@@ -1,4 +1,4 @@
-.project-share__input {
+.page-share__input {
   flex: 1 1 auto;
   height: 36px;
   border: 1px solid $color-white-alpha;

--- a/src/components/PageShare/PageShare.vue
+++ b/src/components/PageShare/PageShare.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="layout-section layout-section--padded-small layout-section--lined project-share ma-3">
+  <section class="layout-section layout-section--padded-small layout-section--lined page-share ma-3">
     <div class="layout-container">
       <v-row class="mb-3">
         <h3 class="p normal">
@@ -28,7 +28,7 @@
             mdi-content-copy
           </v-icon>
         </v-btn>
-        <input type="text" class="project-share__input" :value="shareUrl" readonly>
+        <input type="text" class="page-share__input" :value="shareUrl" readonly>
       </v-row>
     </div>
   </section>
@@ -68,4 +68,4 @@
   }
 </script>
 
-<style src="./ProjectShare.scss" lang="scss"/>
+<style src="./PageShare.scss" lang="scss"/>

--- a/src/components/ReservoirPageSection/ReservoirPageSection.vue
+++ b/src/components/ReservoirPageSection/ReservoirPageSection.vue
@@ -34,8 +34,8 @@
         @selectedTimeChanged="onSelectedTimeChanged"
       />
 
-      <!-- Temporary hide share project for custom selection since this url isn't nice to share -->
-      <ProjectShare v-if="areaType !== 'custom-selection'" title="Share this project" />
+      <!-- Temporary hide share page for custom selection since this url isn't nice to share -->
+      <PageShare v-if="areaType !== 'custom-selection'" title="Share this page" />
     </div>
   </section>
 </template>


### PR DESCRIPTION
Changes
- Use the word "page" instead of "project"
- Internally rename for consistency 


Before:
![image](https://user-images.githubusercontent.com/15196342/204534479-da12adec-8e16-41be-9e00-e0217821f594.png)

After:
![image](https://user-images.githubusercontent.com/15196342/204534414-d05003b0-a0c2-44da-a5cb-bd9b83ffeef8.png)
