### PR TITLE
Fix/GWW-88: Load satellite image after map has been loaded

### DIFF
--- a/src/components/ComparisonDetailMap/ComparisonDetailMap.vue
+++ b/src/components/ComparisonDetailMap/ComparisonDetailMap.vue
@@ -7,7 +7,7 @@
     :zoom="mapConfig.zoom"
     :map-style="mapConfig.style"
     @mb-created="onMapCreated"
-    @mb-load="addReservoirsToMap"
+    @mb-load="onMapLoaded"
   >
     <!-- Controls -->
     <v-mapbox-navigation-control position="bottom-right" />
@@ -24,9 +24,9 @@
         type: Array,
         required: true,
       },
-      satelliteImageUrl: {
-        type: String,
-        default: '',
+      date: {
+        type: Date,
+        default: null,
       },
     },
 
@@ -53,47 +53,39 @@
       },
     },
 
-    watch: {
-      satelliteImageUrl (newURL, oldURL) {
-        // check if there is a layer id that contains the words 'reservoir' and 'line'
+    methods: {
+      async addSatelliteImageToMap () {
+        const geometry = {
+          ...this.reservoirs[0],
+          properties: {
+            t: Math.floor(this.date.getTime() / 1000),
+          },
+        }
+
+        const data = await this.$repo.image.getSatelliteImage(geometry)
+
         const layers = this.map.getStyle().layers
         const layerId = layers.find(layer => layer.id.includes('reservoir') && layer.id.includes('line')).id
 
-        // check if the new URL is different from the old one
-        if (newURL !== oldURL) {
-          // remove the old layer
-          if (this.map.getLayer('satellite')) {
-            this.map.removeLayer('satellite')
-          }
-          // remove the old source
-          if (this.map.getSource('satellite')) {
-            this.map.removeSource('satellite')
-          }
+        // add satellite source as raster to the map
+        this.map.addSource('satellite', {
+          type: 'raster',
+          tiles: [data.url],
+          tileSize: 256,
+        })
 
-          // add satellite source as raster to the map
-          this.map.addSource('satellite', {
-            type: 'raster',
-            tiles: [newURL],
-            tileSize: 256,
-          })
-
-          // add satellite layer to the map
-          this.map.addLayer({
-            id: 'satellite',
-            type: 'raster',
-            source: 'satellite',
-            paint: {
-              'raster-opacity': 1,
-            },
-          }, layerId)
-        }
+        // add satellite layer to the map
+        this.map.addLayer({
+          id: 'satellite',
+          type: 'raster',
+          source: 'satellite',
+          paint: {
+            'raster-opacity': 1,
+          },
+        }, layerId)
       },
-    },
 
-    methods: {
-      addReservoirsToMap (event) {
-        this.map = event.target
-
+      addReservoirsToMap () {
         this.transformedReservoirs.forEach((reservoir) => {
           const reservoirName = `reservoir-${reservoir.data.id}`
 
@@ -108,6 +100,7 @@
               'fill-opacity': 0.7,
             },
           })
+
           this.map.addLayer({
             id: `${reservoirName}-line`,
             type: 'line',
@@ -129,6 +122,12 @@
         map.removeControl(map._logoControl)
         map.addControl(map._logoControl, 'top-right')
         this.$emit('setMap', map)
+      },
+
+      onMapLoaded (event) {
+        this.map = event.target
+        this.addReservoirsToMap()
+        this.addSatelliteImageToMap()
       },
     },
   }

--- a/src/components/ComparisonMap/ComparisonMap.scss
+++ b/src/components/ComparisonMap/ComparisonMap.scss
@@ -1,7 +1,8 @@
 @import "mapbox-gl-compare/dist/mapbox-gl-compare.css";
 
 .comparison-map {
-  margin: $space-xlarge 0;
+  margin-top: 150px;
+  margin-bottom: $space-xlarge;
 }
 
 .comparison-map__map-container {

--- a/src/components/ComparisonMap/ComparisonMap.vue
+++ b/src/components/ComparisonMap/ComparisonMap.vue
@@ -4,7 +4,7 @@
       <ComparisonDetailMap
         v-if="reservoirs.length"
         :reservoirs="reservoirs"
-        :satellite-image-url="oldSatelliteImageUrl"
+        :date="oldDate"
         class="comparison-map__detail-map"
         @setMap="onSetOldMap"
       />
@@ -12,7 +12,7 @@
       <ComparisonDetailMap
         v-if="reservoirs.length"
         :reservoirs="reservoirs"
-        :satellite-image-url="satelliteImageUrl"
+        :date="date"
         class="comparison-map__detail-map"
         @setMap="onSetCurrentMap"
       />
@@ -55,7 +55,6 @@
     },
 
     async mounted () {
-      this.loadSatelliteImages()
       await this.initializeMap()
     },
 
@@ -75,27 +74,6 @@
         const MapboxCompare = (await import('mapbox-gl-compare')).default
         // eslint-disable-next-line no-new
         new MapboxCompare(oldMap, currentMap, '#comparison-map-container')
-      },
-      async loadSatelliteImages () {
-        const geometry = {
-          ...this.reservoirs[0],
-          properties: {
-            t: Math.floor(this.date.getTime() / 1000),
-          },
-        }
-
-        const oldGeometry = {
-          ...this.reservoirs[0],
-          properties: {
-            t: Math.floor(this.oldDate.getTime() / 1000),
-          },
-        }
-
-        const data = await this.$repo.image.getSatelliteImage(geometry)
-        const oldData = await this.$repo.image.getSatelliteImage(oldGeometry)
-
-        this.satelliteImageUrl = data.url
-        this.oldSatelliteImageUrl = oldData.url
       },
     },
   }


### PR DESCRIPTION
When the satellite image is ready before the map is loaded, normally happens when you open in a new tab and let it load without watching that tab, the page breaks. Now we request the image only when the map has loaded.

![image](https://user-images.githubusercontent.com/15196342/206447956-902a7026-5aa4-401d-977e-00c4905034b9.png)
