### PR TITLE
feat: Use firstPublishedAt as the blogpost date

### DIFF
--- a/src/components/CardItem/CardItem.vue
+++ b/src/components/CardItem/CardItem.vue
@@ -31,7 +31,7 @@
         <span class="p small bold">
           {{ author.name }}
         </span>
-        <time class="p small" :datetime="createdAt">{{ parsedDate }}</time>
+        <time class="p small" :datetime="firstPublishedAt">{{ parsedDate }}</time>
       </div>
     </address>
     <article />
@@ -45,7 +45,7 @@
         type: Object,
         required: true,
       },
-      createdAt: {
+      firstPublishedAt: {
         type: String,
         required: true,
       },
@@ -75,7 +75,7 @@
         return `/blog/${this.slug}`
       },
       parsedDate () {
-        const date = new Date(this.createdAt)
+        const date = new Date(this.firstPublishedAt)
         const options = { year: 'numeric', month: 'long', day: 'numeric' }
         return date.toLocaleDateString('en-EN', options)
       },

--- a/src/components/CardsGrid/CardsGrid.vue
+++ b/src/components/CardsGrid/CardsGrid.vue
@@ -3,7 +3,7 @@
     <li v-for="item in items" :key="item.id">
       <CardItem
         :author="item.heroes[0].author"
-        :created-at="item.createdAt"
+        :first-published-at="item.firstPublishedAt"
         :image="item.heroes[0].image"
         :slug="item.slug"
         :text="item.heroes[0].text"

--- a/src/components/PageSections/RelatedSection/RelatedBlogpost.fragment.graphql
+++ b/src/components/PageSections/RelatedSection/RelatedBlogpost.fragment.graphql
@@ -5,7 +5,7 @@
 fragment relatedBlogpostFragment on BlogpostRecord {
   id
   _modelApiKey
-  createdAt
+  firstPublishedAt: _firstPublishedAt
   slug
   title
   heroes {

--- a/src/components/PageSections/RelatedSection/RelatedPaper.fragment.graphql
+++ b/src/components/PageSections/RelatedSection/RelatedPaper.fragment.graphql
@@ -5,7 +5,7 @@
 fragment relatedPaperFragment on PaperRecord {
   id
   _modelApiKey
-  createdAt
+  firstPublishedAt: _firstPublishedAt
   slug
   title
   heroes {

--- a/src/components/PageSections/RelatedSection/RelatedSection.vue
+++ b/src/components/PageSections/RelatedSection/RelatedSection.vue
@@ -8,7 +8,7 @@
         <li v-for="item in items" :key="item.id">
           <CardItem
             :author="item.heroes[0].author"
-            :created-at="item.createdAt"
+            :first-published-at="item.firstPublishedAt"
             :image="item.heroes[0].image"
             :slug="item.slug"
             :model="item._modelApiKey"

--- a/src/pages/blog/index.query.graphql
+++ b/src/pages/blog/index.query.graphql
@@ -33,8 +33,8 @@ query BlogQuery {
       ... on NewsletterSectionRecord { ...newsletterSectionFragment }
     }
   }
-  allBlogposts(orderBy: createdAt_ASC) {
-    createdAt
+  allBlogposts(orderBy: _firstPublishedAt_ASC) {
+    firstPublishedAt: _firstPublishedAt
     _modelApiKey
     id
     slug


### PR DESCRIPTION
Ticket: [GWW-83](https://issuetracker.deltares.nl/browse/GWW-83)

**Main features**
- Use `firstPublishedAt` instead of `createdAt` as the date shown on the blogposts.
- Sort the blogposts by `firstPublishedAt`