### PR TITLE
fix: Only show feedback form when not loading

### DIFF
--- a/src/components/ReservoirPageSection/ReservoirPageSection.vue
+++ b/src/components/ReservoirPageSection/ReservoirPageSection.vue
@@ -61,7 +61,7 @@
       />
 
       <FeedbackForm
-        v-if="showFeedbackForm"
+        v-if="showFeedbackForm && !isLoading"
         :reservoir="reservoirs[0]"
       />
     </div>


### PR DESCRIPTION
Fix for #177 