### PR TITLE
Feat/GWW-99: Add .geojson export and download chart image

### DIFF
--- a/src/components/DataChart/DataChart.vue
+++ b/src/components/DataChart/DataChart.vue
@@ -1,32 +1,14 @@
 <template>
-  <Fragment>
-    <div
-      ref="$chart"
-      :class="{'data-chart': true, 'data-chart--loading': isLoading}"
-    >
-      <v-skeleton-loader
-        v-if="isLoading"
-        class="data-chart__skeleton-loader"
-        type="image"
-      />
-    </div>
+  <div
+    ref="$chart"
+    :class="{'data-chart': true, 'data-chart--loading': isLoading}"
+  >
     <v-skeleton-loader
-      v-if="showExportButton && isLoading"
+      v-if="isLoading"
       class="data-chart__skeleton-loader"
-      type="button"
+      type="image"
     />
-    <v-btn
-      v-else-if="showExportButton"
-      color="blue-grey darken-3 data-chart__button"
-      class="mr-2"
-      @click="exportTimeSeries"
-    >
-      Download .csv
-      <v-icon right>
-        mdi-download
-      </v-icon>
-    </v-btn>
-  </Fragment>
+  </div>
 </template>
 
 <script>
@@ -69,10 +51,6 @@
         type: String,
         default: '',
       },
-      exportTitle: {
-        type: String,
-        default: '',
-      },
       xAxis: {
         type: Array,
         default: () => [],
@@ -84,10 +62,6 @@
       series: {
         type: Array,
         default: () => [],
-      },
-      showExportButton: {
-        type: Boolean,
-        default: false,
       },
       showTooltip: {
         type: Boolean,
@@ -160,11 +134,11 @@
           },
 
           toolbox: useToolbox && {
-            left: 'center',
+            show: true,
+            top: 'bottom',
+            left: 'left',
+            orient: 'vertical',
             feature: {
-              dataZoom: {
-                yAxisIndex: 'none',
-              },
               restore: {},
               saveAsImage: {},
             },
@@ -215,19 +189,6 @@
       this.setupChart()
     },
     methods: {
-      exportTimeSeries () {
-        let csv = `${this.xAxis[0].type},${this.yAxis[0].name}\n`
-        this.series[0].data.forEach((row) => {
-          csv += row.join(',')
-          csv += '\n'
-        })
-
-        const anchor = document.createElement('a')
-        anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv)
-        anchor.target = '_blank'
-        anchor.download = `${this.title || 'reservoir'}.csv`
-        anchor.click()
-      },
       subscribeChartEvents (chart) {
         chart.on('updateAxisPointer', (evt) => {
           if (evt.dataIndexInside) {

--- a/src/components/PageShare/PageShare.vue
+++ b/src/components/PageShare/PageShare.vue
@@ -8,8 +8,8 @@
       />
       <Fragment v-else>
         <v-row class="mb-3">
-          <h3 class="p normal">
-            {{ title }}
+          <h3>
+            Export options
           </h3>
         </v-row>
         <v-row>
@@ -25,6 +25,28 @@
           </v-btn>
           <input type="text" class="page-share__input" :value="shareUrl" readonly>
         </v-row>
+        <v-row v-if="singleReservoir">
+          <v-btn
+            color="blue-grey darken-3 data-chart__button"
+            class="mr-2"
+            @click="exportTimeSeries"
+          >
+            Download .csv
+            <v-icon right>
+              mdi-download
+            </v-icon>
+          </v-btn>
+          <v-btn
+            color="blue-grey darken-3 data-chart__button"
+            class="mr-2"
+            @click="exportGeometry"
+          >
+            Download .geojson
+            <v-icon right>
+              mdi-download
+            </v-icon>
+          </v-btn>
+        </v-row>
       </Fragment>
     </div>
   </section>
@@ -33,11 +55,11 @@
 <script>
   export default {
     props: {
-      title: {
-        type: String,
-        required: true,
-      },
       isLoading: {
+        type: Boolean,
+        default: false,
+      },
+      singleReservoir: {
         type: Boolean,
         default: false,
       },
@@ -58,6 +80,12 @@
         } catch (err) {
           throw new Error('Error: Copy to clipboard')
         }
+      },
+      exportTimeSeries () {
+        this.$emit('exportTimeSeries')
+      },
+      exportGeometry () {
+        this.$emit('exportGeometry')
       },
     },
   }

--- a/src/components/ReservoirPageSection/ReservoirPageSection.vue
+++ b/src/components/ReservoirPageSection/ReservoirPageSection.vue
@@ -169,7 +169,7 @@
         const geometry = JSON.stringify(this.reservoirs[0])
 
         const anchor = document.createElement('a')
-        anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(geometry)
+        anchor.href = 'data:application/geo+json;charset=utf-8,' + encodeURIComponent(geometry)
         anchor.target = '_blank'
         anchor.download = `${this.reservoirs[0].properties.name || 'reservoir'}.geojson`
         anchor.click()

--- a/src/components/ReservoirPageSection/ReservoirPageSection.vue
+++ b/src/components/ReservoirPageSection/ReservoirPageSection.vue
@@ -41,7 +41,7 @@
         :show-tooltip="true"
         :show-legend="true"
         :use-zoom="true"
-        :use-toolbox="false"
+        :use-toolbox="true"
         :is-loading="isLoading || isLoadingChart"
         @selectedTimeChanged="onSelectedTimeChanged"
       />
@@ -56,8 +56,10 @@
       <!-- Temporary hide share page for custom selection since this url isn't nice to share -->
       <PageShare
         v-if="areaType !== 'custom-selection'"
-        title="Share this page"
         :is-loading="isLoading"
+        :single-reservoir="reservoirs.length === 1"
+        @exportTimeSeries="exportTimeSeries"
+        @exportGeometry="exportGeometry"
       />
 
       <FeedbackForm
@@ -149,6 +151,28 @@
     methods: {
       onSelectedTimeChanged (time) {
         this.$emit('onSelectedTimeChanged', time)
+      },
+      exportTimeSeries () {
+        let csv = `${this.xAxis[0].type},${this.yAxis[0].name}\n`
+        this.series[0].data.forEach((row) => {
+          csv += row.join(',')
+          csv += '\n'
+        })
+
+        const anchor = document.createElement('a')
+        anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv)
+        anchor.target = '_blank'
+        anchor.download = `${this.chartTitle || 'reservoir'}.csv`
+        anchor.click()
+      },
+      exportGeometry () {
+        const geometry = JSON.stringify(this.reservoirs[0])
+
+        const anchor = document.createElement('a')
+        anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(geometry)
+        anchor.target = '_blank'
+        anchor.download = `${this.reservoirs[0].properties.name || 'reservoir'}.geojson`
+        anchor.click()
       },
     },
   }


### PR DESCRIPTION
Ticket: [GWW-99](https://issuetracker.deltares.nl/browse/GWW-99)

**Main features**
- Enable download image option on the chart for basins, adm areas, custom selections and single reservoirs
- Add .geojson export for single reservoirs
- Move .csv export to export area at the bottom of the page

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/15196342/220345449-abe05b0b-74fa-41ae-b6e1-9dcb1fd0ba31.png">

To download an image on the chart click on the arrow on the left.
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/15196342/220345531-6791974f-812f-4cd8-9117-657f69590cf0.png">
