### PR TITLE
Feat/GWW-127: Use "select" instead of "draw" for custom selections

### DIFF
--- a/src/components/MapLayersPanel/MapLayersPanel.vue
+++ b/src/components/MapLayersPanel/MapLayersPanel.vue
@@ -20,6 +20,9 @@
       @click="onDrawButtonClick"
     >
       {{ drawButtonText }}
+      <v-icon v-if="!isDrawing && !drawnFeatures.length" right>
+        mdi-vector-polyline-edit
+      </v-icon>
     </v-btn>
   </div>
 </template>
@@ -276,9 +279,9 @@
         return this.$store.getters['drawn-geometry/isDrawing']
       },
       drawButtonText () {
-        if (this.isDrawing) { return 'Drawing geometry' }
-        if (this.drawnFeatures.length) { return 'View geometry details' }
-        return 'Draw custom geometry'
+        if (this.isDrawing) { return 'Selecting reservoir' }
+        if (this.drawnFeatures.length) { return 'View selected reservoir details' }
+        return 'Select custom reservoir'
       },
     },
 


### PR DESCRIPTION
Ticket: [GWW-127](https://issuetracker.deltares.nl/browse/GWW-127)

**Main features**:
- Use word "select" instead of "draw" for clarity
- Add icon to represent the drawing 

<img width="396" alt="image" src="https://user-images.githubusercontent.com/15196342/220378943-ba01af18-a987-4289-ac46-693bbe31d213.png">
