### PR TITLE
Feat/GWW-126: use datepickers on the comparison map

### DIFF
--- a/src/assets/scss/overwrites.scss
+++ b/src/assets/scss/overwrites.scss
@@ -16,3 +16,8 @@
   padding-left: 0;
   list-style: none;
 }
+
+.v-application .accent {
+  background-color: $color-blue-light !important;
+  border-color: $color-blue-light !important;
+}

--- a/src/assets/scss/overwrites.scss
+++ b/src/assets/scss/overwrites.scss
@@ -9,6 +9,17 @@
 
 .v-application {
   font-weight: $font-weight-normal;
+
+  .v-date-picker-table, .v-date-picker-header {
+    .accent {
+      background-color: $color-blue-light !important;
+      border-color: $color-blue-light !important;
+    }
+    .accent--text {
+      color: $color-blue-light !important;
+      caret-color: $color-blue-light !important;
+    }
+  }
 }
 
 .v-application .v-application--wrap ol,
@@ -17,7 +28,4 @@
   list-style: none;
 }
 
-.v-application .accent {
-  background-color: $color-blue-light !important;
-  border-color: $color-blue-light !important;
-}
+

--- a/src/components/ComparisonMap/ComparisonMap.scss
+++ b/src/components/ComparisonMap/ComparisonMap.scss
@@ -28,6 +28,10 @@
     margin: 0;
   }
 
+  .comparison-map__date-picker {
+    width: 90px;
+  }
+
   .comparison-map__date-picker--right {
     input {
       text-align: right;

--- a/src/components/ComparisonMap/ComparisonMap.scss
+++ b/src/components/ComparisonMap/ComparisonMap.scss
@@ -22,6 +22,11 @@
   display: flex;
   justify-content: space-between;
   margin-top: $space-medium;
+
+  .v-input {
+    padding: 0;
+    margin: 0;
+  }
 }
 
 .comparison-map__loading {

--- a/src/components/ComparisonMap/ComparisonMap.scss
+++ b/src/components/ComparisonMap/ComparisonMap.scss
@@ -27,6 +27,12 @@
     padding: 0;
     margin: 0;
   }
+
+  .comparison-map__date-picker--right {
+    input {
+      text-align: right;
+    }
+  }
 }
 
 .comparison-map__loading {

--- a/src/components/ComparisonMap/ComparisonMap.vue
+++ b/src/components/ComparisonMap/ComparisonMap.vue
@@ -114,8 +114,8 @@
 
     data () {
       return {
-        isoDate: (new Date()).toISOString().substring(0, 10),
-        isoOldDate: (new Date()).toISOString().substring(0, 10),
+        isoDate: this.isoFormatDate(new Date()),
+        isoOldDate: this.isoFormatDate(new Date()),
         isLoadingSatelliteImages: false,
         datePickerMenu: false,
         oldDatePickerMenu: false,
@@ -127,7 +127,7 @@
         return this.timeSeries[0].data.map(item => new Date(item[0]))
       },
       isoTimeSeriesDates () {
-        return this.timeSeriesDates.map(date => date.toISOString().substring(0, 10))
+        return this.timeSeriesDates.map(date => this.isoFormatDate(date))
       },
       date () {
         return new Date(this.isoDate)
@@ -160,16 +160,10 @@
         // On mounted, `date` is the last date in the time series
         // `oldDate` is the closest date in the time series one year before `date`
         const date = this.timeSeriesDates[this.timeSeriesDates.length - 1]
-        this.isoDate = date.toISOString().substring(0, 10)
+        this.isoDate = this.isoFormatDate(date)
         const oldDate = new Date(date.getTime())
         oldDate.setFullYear(date.getFullYear() - 1)
-        this.isoOldDate = this.timeSeriesDates[this.getNearestDateIndex(oldDate)].toISOString().substring(0, 10)
-      },
-      formatDate (date) {
-        if (!date) { return null }
-
-        const [year, month, day] = date.split('-')
-        return `${day}/${month}/${year}`
+        this.isoOldDate = this.isoFormatDate(this.timeSeriesDates[this.getNearestDateIndex(oldDate)])
       },
       onSetCurrentMap (map) {
         currentMap = map
@@ -204,6 +198,17 @@
       },
       allowedDates (date) {
         return this.isoTimeSeriesDates.includes(date)
+      },
+      formatDate (date) {
+        if (!date) { return null }
+
+        const [year, month, day] = date.split('-')
+        return `${day}/${month}/${year}`
+      },
+      // v-date-picker accepts ISO 8601 date strings (YYYY-MM-DD)
+      // https://v2.vuetifyjs.com/en/components/date-pickers/#caveats
+      isoFormatDate (date) {
+        return date.toISOString().substring(0, 10)
       },
     },
   }

--- a/src/components/ComparisonMap/ComparisonMap.vue
+++ b/src/components/ComparisonMap/ComparisonMap.vue
@@ -25,27 +25,29 @@
       />
     </div>
 
-    <div class="comparison-map__dates">
+    <div class="comparison-map__dates ma-3">
       <div>
-        <v-btn
-          icon
-          color="primary"
-          :disabled="!previousOldDate || isLoadingSatelliteImages"
-          :title="parseDate(previousOldDate)"
-          @click="() => oldDateIndex = previousOldDateIndex"
+        <v-menu
+          transition="scale-transition"
+          offset-y
+          max-width="290px"
+          min-width="auto"
         >
-          <v-icon>mdi-chevron-left</v-icon>
-        </v-btn>
-        <span>{{ parseDate(oldDate) }}</span>
-        <v-btn
-          icon
-          color="primary"
-          :disabled="!nextOldDate || isLoadingSatelliteImages"
-          :title="parseDate(nextOldDate)"
-          @click="() => oldDateIndex = nextOldDateIndex"
-        >
-          <v-icon>mdi-chevron-right</v-icon>
-        </v-btn>
+          <template #activator="{ on, attrs }">
+            <v-text-field
+              v-model="formattedOldDate"
+              readonly
+              v-bind="attrs"
+              v-on="on"
+            />
+          </template>
+          <v-date-picker
+            v-model="isoOldDate"
+            :allowed-dates="allowedDates"
+            no-title
+            scrollable
+          />
+        </v-menu>
       </div>
       <div v-if="isLoadingSatelliteImages" class="comparison-map__loading">
         <div>
@@ -55,25 +57,30 @@
         This feature is not optimized for larger reservoirs.
       </div>
       <div>
-        <v-btn
-          icon
-          color="primary"
-          :disabled="!previousDate || isLoadingSatelliteImages"
-          :title="parseDate(previousDate)"
-          @click="() => dateIndex = previousDateIndex"
+        <v-menu
+          :close-on-content-click="true"
+          transition="scale-transition"
+          location="bottom center"
+          origin="overlap"
+          offset-y
+          max-width="290px"
+          min-width="auto"
         >
-          <v-icon>mdi-chevron-left</v-icon>
-        </v-btn>
-        <span>{{ parseDate(date) }}</span>
-        <v-btn
-          icon
-          color="primary"
-          :disabled="!nextDate || isLoadingSatelliteImages"
-          :title="parseDate(nextDate)"
-          @click="() => dateIndex = nextDateIndex"
-        >
-          <v-icon>mdi-chevron-right</v-icon>
-        </v-btn>
+          <template #activator="{ on, attrs }">
+            <v-text-field
+              v-model="formattedDate"
+              readonly
+              v-bind="attrs"
+              v-on="on"
+            />
+          </template>
+          <v-date-picker
+            v-model="isoDate"
+            :allowed-dates="allowedDates"
+            no-title
+            scrollable
+          />
+        </v-menu>
       </div>
     </div>
   </div>
@@ -100,45 +107,30 @@
 
     data () {
       return {
-        dateIndex: -1,
-        oldDateIndex: -1,
+        isoDate: (new Date()).toISOString().substring(0, 10),
+        isoOldDate: (new Date()).toISOString().substring(0, 10),
         isLoadingSatelliteImages: false,
       }
     },
 
     computed: {
-      date () {
-        return this.timeSeriesDates[this.dateIndex]
-      },
-      oldDate () {
-        return this.timeSeriesDates[this.oldDateIndex]
-      },
       timeSeriesDates () {
         return this.timeSeries[0].data.map(item => new Date(item[0]))
       },
-      previousDateIndex () {
-        return this.dateIndex - 1
+      isoTimeSeriesDates () {
+        return this.timeSeriesDates.map(date => date.toISOString().substring(0, 10))
       },
-      nextDateIndex () {
-        return this.dateIndex + 1
+      date () {
+        return new Date(this.isoDate)
       },
-      previousDate () {
-        return this.timeSeriesDates[this.previousDateIndex]
+      oldDate () {
+        return new Date(this.isoOldDate)
       },
-      nextDate () {
-        return this.timeSeriesDates[this.nextDateIndex]
+      formattedDate () {
+        return this.formatDate(this.isoDate)
       },
-      previousOldDateIndex () {
-        return this.oldDateIndex - 1
-      },
-      nextOldDateIndex () {
-        return this.oldDateIndex + 1
-      },
-      previousOldDate () {
-        return this.timeSeriesDates[this.previousOldDateIndex]
-      },
-      nextOldDate () {
-        return this.timeSeriesDates[this.nextOldDateIndex]
+      formattedOldDate () {
+        return this.formatDate(this.isoOldDate)
       },
     },
 
@@ -159,14 +151,16 @@
         // On mounted, `date` is the last date in the time series
         // `oldDate` is the closest date in the time series one year before `date`
         const date = this.timeSeriesDates[this.timeSeriesDates.length - 1]
+        this.isoDate = date.toISOString().substring(0, 10)
         const oldDate = new Date(date.getTime())
         oldDate.setFullYear(date.getFullYear() - 1)
-        this.dateIndex = this.timeSeriesDates.length - 1
-        this.oldDateIndex = this.getNearestDateIndex(oldDate)
+        this.isoOldDate = this.timeSeriesDates[this.getNearestDateIndex(oldDate)].toISOString().substring(0, 10)
       },
-      parseDate (date) {
-        const options = { year: 'numeric', month: 'long', day: 'numeric' }
-        return date?.toLocaleDateString('en-EN', options)
+      formatDate (date) {
+        if (!date) { return null }
+
+        const [year, month, day] = date.split('-')
+        return `${day}/${month}/${year}`
       },
       onSetCurrentMap (map) {
         currentMap = map
@@ -198,6 +192,9 @@
         })
 
         return bestDate
+      },
+      allowedDates (date) {
+        return this.isoTimeSeriesDates.includes(date)
       },
     },
   }

--- a/src/components/ComparisonMap/ComparisonMap.vue
+++ b/src/components/ComparisonMap/ComparisonMap.vue
@@ -26,9 +26,10 @@
     </div>
 
     <div id="comparison-map" class="comparison-map__dates ma-3">
-      <div>
+      <div class="comparison-map__date-picker">
         <v-menu
-          :close-on-content-click="true"
+          v-model="oldDatePickerMenu"
+          :close-on-content-click="false"
           transition="scale-transition"
           origin="overlap"
           offset-y
@@ -49,6 +50,7 @@
             :allowed-dates="allowedDates"
             no-title
             scrollable
+            @change="oldDatePickerMenu = false"
           />
         </v-menu>
       </div>
@@ -59,9 +61,10 @@
         </div>
         This feature is not optimized for larger reservoirs.
       </div>
-      <div>
+      <div class="comparison-map__date-picker comparison-map__date-picker--right">
         <v-menu
-          :close-on-content-click="true"
+          v-model="datePickerMenu"
+          :close-on-content-click="false"
           transition="scale-transition"
           origin="overlap"
           offset-y
@@ -72,7 +75,6 @@
           <template #activator="{ on, attrs }">
             <v-text-field
               v-model="formattedDate"
-              class="comparison-map__date-picker--right"
               readonly
               v-bind="attrs"
               v-on="on"
@@ -83,6 +85,7 @@
             :allowed-dates="allowedDates"
             no-title
             scrollable
+            @change="datePickerMenu = false"
           />
         </v-menu>
       </div>
@@ -114,6 +117,8 @@
         isoDate: (new Date()).toISOString().substring(0, 10),
         isoOldDate: (new Date()).toISOString().substring(0, 10),
         isLoadingSatelliteImages: false,
+        datePickerMenu: false,
+        oldDatePickerMenu: false,
       }
     },
 

--- a/src/components/ComparisonMap/ComparisonMap.vue
+++ b/src/components/ComparisonMap/ComparisonMap.vue
@@ -25,13 +25,16 @@
       />
     </div>
 
-    <div class="comparison-map__dates ma-3">
+    <div id="comparison-map" class="comparison-map__dates ma-3">
       <div>
         <v-menu
+          :close-on-content-click="true"
           transition="scale-transition"
+          origin="overlap"
           offset-y
           max-width="290px"
           min-width="auto"
+          right
         >
           <template #activator="{ on, attrs }">
             <v-text-field
@@ -60,15 +63,16 @@
         <v-menu
           :close-on-content-click="true"
           transition="scale-transition"
-          location="bottom center"
           origin="overlap"
           offset-y
           max-width="290px"
           min-width="auto"
+          left
         >
           <template #activator="{ on, attrs }">
             <v-text-field
               v-model="formattedDate"
+              class="comparison-map__date-picker--right"
               readonly
               v-bind="attrs"
               v-on="on"


### PR DESCRIPTION
Ticket: [GWW-126](https://issuetracker.deltares.nl/browse/GWW-126)

**Main features:**
- Replace the date with arrows for date pickers on the comparison map
- Only allow selecting dates on the time series
- Override accent color for all date pickers
- The date picker adjust it's positioning to be always fully visible


<img width="715" alt="image" src="https://user-images.githubusercontent.com/15196342/221193717-6b6119b3-ff61-4a78-a994-4a8f46b9c9b8.png">
