### PR TITLE
Fix/GWW-155: show the map with only the selected area if there are no reservoirs

### DIFF
--- a/src/components/DetailMap/DetailMap.vue
+++ b/src/components/DetailMap/DetailMap.vue
@@ -120,6 +120,7 @@
         if (this.geometry) {
           this.addGeometryToMap(map)
         }
+        this.setBoundingBox(map)
       },
 
       addTransformedReservoirsToMap (map) {
@@ -147,10 +148,6 @@
               'line-width': 1,
             },
           })
-
-          const allFeatures = featureCollection(this.transformedReservoirs.map(reservoir => reservoir.data))
-          const boundingBox = bbox(allFeatures)
-          map.fitBounds(boundingBox, { padding: 40 })
         })
       },
 
@@ -234,6 +231,16 @@
             'line-dasharray': [2, 1],
           },
         })
+      },
+
+      setBoundingBox (map) {
+        const allFeatures = featureCollection(
+          this.transformedReservoirs.length
+            ? this.transformedReservoirs.map(reservoir => reservoir.data)
+            : [{ type: 'Feature', geometry: this.geometry }],
+        )
+        const boundingBox = bbox(allFeatures)
+        map.fitBounds(boundingBox, { padding: 40 })
       },
 
       onReservoirClick (evt) {

--- a/src/components/ReservoirList/ReservoirList.vue
+++ b/src/components/ReservoirList/ReservoirList.vue
@@ -21,6 +21,11 @@
       </li>
     </ul>
   </div>
+  <div v-else-if="reservoirs.length === 0" class="reservoir-list">
+    <p class="p">
+      No reservoirs included.
+    </p>
+  </div>
 </template>
 
 <script>

--- a/src/components/ReservoirPageSection/ReservoirPageSection.vue
+++ b/src/components/ReservoirPageSection/ReservoirPageSection.vue
@@ -2,7 +2,6 @@
   <section class="reservoir-page-section layout-section layout-section--lined">
     <div class="layout-container">
       <DetailMap
-        v-if="reservoirs.length || isLoading"
         :reservoirs="reservoirs"
         :geometry="geometry"
         :satellite-image-url="satelliteImageUrl"
@@ -33,7 +32,7 @@
       </div>
 
       <data-chart
-        v-if="timeSeries || isLoading || isLoadingChart"
+        v-if="(reservoirs.length && timeSeries) || isLoading || isLoadingChart"
         :title="chartTitle"
         :show-export-button="showExportButton"
         :x-axis="xAxis"


### PR DESCRIPTION
Ticket: [GWW-155](https://issuetracker.deltares.nl/browse/GWW-155)

**Bug:** when selecting an area (basin/adm region/custom area) without any reservoirs the backend returned an error and the website got stuck. After changing the backend response, the website didn't got stuck but tried to render the chart without data.

**Solution:** in combination with #186 when the user selects an area without reservoirs the detail page shows the map with the selected area and no reservoirs. It includes a text under the heading (where we normally have the list of reservoirs) explaining there are no reservoirs in that area. No chart is shown.

<img width="946" alt="image" src="https://user-images.githubusercontent.com/15196342/220416925-8be954da-c3f9-41f4-b10b-87fb123a507c.png">
