### PR TITLE
Feat/GWW-135 zoom in based on latest selected reservoir

### DIFF
--- a/src/components/DetailMap/DetailMap.vue
+++ b/src/components/DetailMap/DetailMap.vue
@@ -67,6 +67,9 @@
           },
         }))
       },
+      latestSelectedReservoirCoordinates () {
+        return this.$store.getters['reservoir/latestSelectedReservoirCoordinates']
+      },
     },
 
     watch: {
@@ -110,6 +113,12 @@
       onMapCreated (map) {
         map.removeControl(map._logoControl)
         map.addControl(map._logoControl, 'top-right')
+
+        this.mapConfig = {
+          ...this.mapConfig,
+          zoom: this.latestSelectedReservoirCoordinates.zoom,
+          center: this.latestSelectedReservoirCoordinates.center,
+        }
       },
 
       onMapLoaded (event) {
@@ -247,6 +256,15 @@
         map.fitBounds(boundingBox, { padding: 40 })
       },
 
+      setLatestSelectedReservoirCoordinates (map) {
+        // get zoom and center of the current map when zooming ended
+        this.zoom = map.getZoom()
+        this.center = map.getCenter().toArray()
+
+        // set the current zoom and center to the store
+        this.$store.commit('reservoir/SET_LATEST_SELECTED_RESERVOIR_COORDINATES', { zoom: this.zoom, center: this.center })
+      },
+
       onReservoirClick (evt) {
         const reservoir = evt.features?.[0]
         if (!reservoir) {
@@ -254,6 +272,7 @@
         }
         const fid = reservoir.properties?.fid || reservoir.id
 
+        this.setLatestSelectedReservoirCoordinates(map)
         this.$router.push({ path: `/reservoir/${fid}` })
       },
     },

--- a/src/pages/map.vue
+++ b/src/pages/map.vue
@@ -12,6 +12,7 @@
     destroyed () {
       this.$store.commit('zoomable-layers/REMOVE_ALL_LAYERS')
       this.$store.commit('reservoir-layers/REMOVE_ALL_LAYERS')
+      this.$store.commit('reservoir/RESET_LATEST_SELECTED_RESERVOIR_COORDINATES')
     },
   }
 </script>

--- a/src/store/reservoir.js
+++ b/src/store/reservoir.js
@@ -1,0 +1,24 @@
+import { MAP_CENTER, MAP_ZOOM } from '@/lib/constants'
+
+export const state = () => ({
+  latestSelectedReservoirCoordinates: {
+    zoom: MAP_ZOOM,
+    center: MAP_CENTER,
+  },
+})
+
+export const getters = {
+  latestSelectedReservoirCoordinates: state => state.latestSelectedReservoirCoordinates,
+}
+
+export const mutations = {
+  SET_LATEST_SELECTED_RESERVOIR_COORDINATES (state, payload) {
+    state.latestSelectedReservoirCoordinates = payload
+  },
+  RESET_LATEST_SELECTED_RESERVOIR_COORDINATES (state) {
+    state.latestSelectedReservoirCoordinates = {
+      zoom: MAP_ZOOM,
+      center: MAP_CENTER,
+    }
+  },
+}


### PR DESCRIPTION
Ticket: [GWW-135](https://issuetracker.deltares.nl/browse/GWW-135)
 
**Main features**

- [feat: zoom in based on latest selected reservoir coordinates](https://github.com/global-water-watch/global-water-watch-website/commit/d6355de0794d20a56dc0459c8cebaa3765437a64)
- [feat: reset latest selected reservoir coordinates on destroyed hook i…](https://github.com/global-water-watch/global-water-watch-website/commit/64d263715e47bc66fa6f30c0f3543750c1ae8fb9)

**How to test**
1. Go to the map and selected a reservoir thats close to another reservoir
2. On the reservoir page click a reservoir next to the other reservoir
3. The map will not zoom in from the world perspective but from the latest selected reservoir coordinates