### PR TITLE
Prevent duplicate layer errors in map zoom

### DIFF
--- a/src/components/MapLayerZoomable/MapLayerZoomable.js
+++ b/src/components/MapLayerZoomable/MapLayerZoomable.js
@@ -58,15 +58,26 @@ export default {
       const layer = this.options.layers.find(({ id }) => id === layerId)
       const { styles, clickFn, promoteId, attribution } = this.options
 
-      map.addSource(layerId, {
-        id: layerId,
-        promoteId,
-        attribution: attribution || '',
-        ...layer.source,
-      })
+      // add source only if it doesn't exist
+      // this prevents an error that makes the app unusable
+      if (!map.getSource(layerId)) {
+        map.addSource(layerId, {
+          id: layerId,
+          promoteId,
+          attribution: attribution || '',
+          ...layer.source,
+        })
+      }
 
       styles.forEach((style) => {
         const layerUniqueId = `${layerId}-${style.type}`
+
+        // remove layer if it already exists
+        // this prevents an error that makes the app unusable
+        if (map.getLayer(layerUniqueId)) {
+          map.removeLayer(layerUniqueId)
+        }
+
         map.addLayer({
           id: layerUniqueId,
           type: style.type,


### PR DESCRIPTION
Fixes this issue:

<div>
    <a href="https://www.loom.com/share/bf5acceac27e4c11bfb91c9d4140497b">
      <p>Global Water Watch - 24 April 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/bf5acceac27e4c11bfb91c9d4140497b">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/bf5acceac27e4c11bfb91c9d4140497b-00001.jpg">
    </a>
  </div>
  
 It throws errors in two situations, either about the layer or the source already existing. After the errors the regions are not shown anymore.